### PR TITLE
Do not clone request and response before parsing

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -177,9 +177,9 @@ class Span {
   public finish() {
     this.eventMeta.duration_ms = Date.now() - this.eventMeta.timestamp
     if (this.isRootSpan() && this.config.parse && this.request) {
-      this.addData(this.config.parse(this.request.clone(), this.response?.clone()))
+      this.addData(this.config.parse(this.request, this.response))
     } else if (this.request && this.config.parseSubrequest) {
-      this.addData(this.config.parseSubrequest(this.request.clone(), this.response?.clone()))
+      this.addData(this.config.parseSubrequest(this.request, this.response))
     }
   }
 


### PR DESCRIPTION
The documentation for Request() and Response() indicate
that you will get a TypeError if the body has already
been used. Since the clone() calls in finish() happen at
the very end of the processing, the request body will most
likely have been used, and the error is thrown. Better to
just let the supplied parse() function do the clone() if
it is appropriate.