### PR TITLE
logging: fix getSampleRate to work with error spans

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -252,12 +252,8 @@ export class RequestTracer extends Span {
     } else if (typeof data.response === 'object' && typeof data.response.status === 'number') {
       const key = `${data.response.status.toString()[0]}xx` as HttpStatusBuckets
       return sampleRates[key] || 1
-    } else if (sampleRates.exception) {
-      // an exception occurred, always send these
-      return 1
     } else {
-      // not a valid response and not an error, I guess we should log this?
-      return 1
+      return sampleRates.exception
     }
   }
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -249,11 +249,15 @@ export class RequestTracer extends Span {
     const sampleRates = this.config.sampleRates
     if (typeof sampleRates === 'function') {
       return sampleRates(data)
-    } else if (!data.response && !data.response.status) {
-      return sampleRates.exception
-    } else {
+    } else if (typeof data.response === 'object' && typeof data.response.status === 'number') {
       const key = `${data.response.status.toString()[0]}xx` as HttpStatusBuckets
       return sampleRates[key] || 1
+    } else if (sampleRates.exception) {
+      // an exception occurred, always send these
+      return 1
+    } else {
+      // not a valid response and not an error, I guess we should log this?
+      return 1
     }
   }
 }


### PR DESCRIPTION
getSampleRate would fail because error spans would not have a response object set,
which results in a `Cannot read properties of undefined (reading 'status')` error. Fix this
by inverting the logic. Also, make sure we return a number instead of a boolean when the
exception property is set.