### PR TITLE
`fetch` TS types are not drop-in

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -143,7 +143,7 @@ export class Span {
     this.eventMeta.duration_ms = Date.now() - this.eventMeta.timestamp
   }
 
-  public fetch(input: Request, init?: RequestInit): Promise<Response> {
+  public fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
     const request = new Request(input, init)
     const childSpan = this.startChildSpan(request.url, 'fetch')
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2018",
     "declaration": true,
     "outDir": "./dist",
-    "lib": ["es2020"],
+    "lib": ["es2020", "webworker"],
     "types": ["@cloudflare/workers-types"],
     "strict": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2018",
     "declaration": true,
     "outDir": "./dist",
-    "lib": ["es2020", "webworker"],
+    "lib": ["es2020"],
     "types": ["@cloudflare/workers-types"],
     "strict": true
   },


### PR DESCRIPTION
As I understand it, the `fetch` method found on `request.tracer.fetch` is meant to be a drop-in replacement, but the types are not an exact match for the built-in `fetch`, which leads to having to resort to casting in certain situations. Specifically the `input` param should be `Request | string` (or aliased by `RequestInfo`).