### PR TITLE
feat: debugLog option for disabling console.log on response

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ const worker = {
 }
 
 const config = {
-  apiKey: '__HONEYCOMB_API_KEY__',
+  apiKey: '__HONEYCOMB_API_KEY__',  // can also be provided by setting env var HONEYCOMB_API_KEY
   dataset: 'my-first-dataset',
 }
 
@@ -119,7 +119,7 @@ const worker = {
 }
 
 const config = {
-  apiKey: '__HONEYCOMB_API_KEY__',
+  apiKey: '__HONEYCOMB_API_KEY__', // can also be provided by setting env var HONEYCOMB_API_KEY
   dataset: 'my-first-dataset',
 }
 
@@ -136,9 +136,8 @@ The config object can take a few extra parameters to add more detail to the even
 
 ```typescript
 interface Config {
-  apiKey: string //The honeycomb API Key
-  dataset: string //The name of the dataset
-
+  apiKey?: string //The honeycomb API Key, can be specified as env var HONEYCOMB_API_KEY
+  dataset?: string //The name of the dataset, can be specified as env var HONEYCOMB_DATASET
   acceptTraceContext?: boolean //Do you want to accept automatic TraceContext information from clients? Defaults to 'false'
   data?: any //Any data you want to add to every request. Things like service name, version info etc.
   redactRequestHeaders?: string[] //Array of headers to redact. Will replace value with `REDACTED`. default is ['authorization', 'cookie', 'referer'].
@@ -146,6 +145,7 @@ interface Config {
   sampleRates?: SampleRates | SampleRateFn //Either an object or function that configured sampling ([See below](#dynamic-sampling))
   sendTraceContext?: boolean | RegExp //set this to true to send a TraceContext with all fetch requests. With a Regex, we will check the URL against the regex first. Defaults to 'false'
   serviceName?: string //The serviceName you want to see in Honeycomb. Defaults to 'worker'
+  debugLog?: boolean // console.log response info for Honeycomb requests. Defaults to true
 }
 ```
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,7 @@ export type ResolvedConfig = {
   sampleRates: SampleRates | SampleRateFn
   serviceName: string
   sendTraceContext: boolean | RegExp
+  debugLog: boolean
 }
 
 export type Config = Partial<ResolvedConfig>
@@ -59,6 +60,7 @@ const configDefaults: ResolvedConfig = {
   sampleRates: () => 1,
   sendTraceContext: false,
   serviceName: 'worker',
+  debugLog: true,
 }
 
 function resolve(cfg: Config): ResolvedConfig {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -237,9 +237,15 @@ export class RequestTracer extends Span {
     }
     const request = new Request(url, params)
     const response = await fetch(request)
-    console.log('Honeycomb Response Status: ' + response.status)
+    this.debugLog('Honeycomb Response Status: ' + response.status)
     const text = await response.text()
-    console.log('Response: ' + text)
+    this.debugLog('Response: ' + text)
+  }
+
+  private debugLog(msg: string) {
+    if (this.config.debugLog) {
+      console.log(msg)
+    }
   }
 
   private getSampleRate(data: any): number {


### PR DESCRIPTION
Noticed there were logs showing up for each request adding HC traces:
```
Honeycomb Response Status: 200
Response: [{"status":202},{"status":202}]
```

- Adds option `debugLog` to disable the `console.log` on the Honeycomb API response, defaults to `true` to match existing behavior
- Adds additional comments to the README.md indicating `HONEYCOMB_API_KEY` / `HONEYCOMB_DATASET` can be specified via env vars