### PR TITLE
Log error rather than throwing on incorrect configuration

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -164,7 +164,10 @@ function workerProxy<T>(config: ResolvedConfig, mod: ExportedHandler<T>): Export
         config.dataset = env.HONEYCOMB_DATASET || config.dataset
 
         if (!config.apiKey || !config.dataset) {
-          throw new Error('Need both HONEYCOMB_API_KEY and HONEYCOMB_DATASET to be configured.')
+          console.error(
+            new Error('Need both HONEYCOMB_API_KEY and HONEYCOMB_DATASET to be configured. Skipping trace.'),
+          )
+          return Reflect.apply(target, thisArg, argArray)
         }
 
         const ctx = argArray[2] as ExecutionContext
@@ -215,7 +218,8 @@ function proxyObjFetch(config: ResolvedConfig, orig_fetch: DoFetch, do_name: str
       config.dataset = env.HONEYCOMB_DATASET || config.dataset
 
       if (!config.apiKey || !config.dataset) {
-        throw new Error('Need both HONEYCOMB_API_KEY and HONEYCOMB_DATASET to be configured.')
+        console.error(new Error('Need both HONEYCOMB_API_KEY and HONEYCOMB_DATASET to be configured. Skipping trace.'))
+        return Reflect.apply(target, thisArg, argArray)
       }
 
       tracer.eventMeta.service.name = do_name


### PR DESCRIPTION
While working on #32 I noticed two things:

- The library has code that throws on incorrect config (added in https://github.com/cloudflare/workers-honeycomb-logger/commit/2d6806a142d5ac9186f168869a5da7360dff1dcc)
- [Version 2.2.0](https://github.com/cloudflare/workers-honeycomb-logger/commit/ea6798176839a200cac330bfd306cc452431149e) is not actually published anywhere on npm (latest is 2.1.0): https://www.npmjs.com/package/@cloudflare/workers-honeycomb-logger

Throwing on a misconfiguration for a logging tool seems a bit unexpected, as you might push a worker and forget to add the environment variable before enabling. This changes it to be a `console.error`, which should be loud enough to tell you something is wrong, but without breaking the core functionality of the worker if you made a mistake.