### PR TITLE
fix: DurableObject fetch does not receive env

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -202,15 +202,13 @@ function workerProxy<T>(config: ResolvedConfig, mod: ExportedHandler<T>): Export
 
 type DoFetch = DurableObject['fetch']
 
-function proxyObjFetch(config: ResolvedConfig, orig_fetch: DoFetch, do_name: string): DoFetch {
+function proxyObjFetch(config: ResolvedConfig, orig_fetch: DoFetch, do_name: string, env: HoneycombEnv): DoFetch {
   return new Proxy(orig_fetch, {
-    apply: (target, thisArg, argArray): Promise<Response> => {
+    apply: (target, thisArg, argArray: Parameters<DurableObject['fetch']>): Promise<Response> => {
       const request = argArray[0] as Request
 
-      const tracer = new RequestTracer(request, config)
+      const tracer = (request.tracer = new RequestTracer(request, config))
 
-      const env = argArray[1] as HoneycombEnv
-      argArray[1] = proxyEnv(env, tracer)
       config.apiKey = env.HONEYCOMB_API_KEY || config.apiKey
       config.dataset = env.HONEYCOMB_DATASET || config.dataset
 
@@ -220,7 +218,6 @@ function proxyObjFetch(config: ResolvedConfig, orig_fetch: DoFetch, do_name: str
 
       tracer.eventMeta.service.name = do_name
       tracer.eventMeta.name = new URL(request.url).pathname
-      request.tracer = tracer
       try {
         const result: Response | Promise<Response> = Reflect.apply(target, thisArg, argArray)
         if (result instanceof Response) {
@@ -254,15 +251,16 @@ export function wrapModule<T>(cfg: Config, mod: ExportedHandler<T>): ExportedHan
   return workerProxy(config, mod)
 }
 
-type DOClass = { new (...args: any[]): DurableObject }
+type DOClass = { new (state: DurableObjectState, env: HoneycombEnv): DurableObject }
 
 export function wrapDurableObject(cfg: Config, do_class: DOClass): DOClass {
   const config = resolve(cfg)
   config.acceptTraceContext = true
   return new Proxy(do_class, {
-    construct: (target, argArray) => {
-      const obj = new target(...argArray)
-      obj.fetch = proxyObjFetch(config, obj.fetch, do_class.name)
+    construct: (target, argArray: ConstructorParameters<DOClass>) => {
+      const env = argArray[1]
+      const obj = new target(...argArray) as DurableObject
+      obj.fetch = proxyObjFetch(config, obj.fetch, do_class.name, env)
       return obj
     },
   })


### PR DESCRIPTION
The DurableObject `fetch` does not an `env` arg the same way as the worker's fetch. Instead it's available in the constructor. 

Passes the `env` correctly from the constructor and improves the typings a bit, otherwise you'll receive `TypeError: Cannot create proxy with a non-object as target or handler` when passing to `proxyEnv` (which we wouldn't want to do in a DO, since env is shared between all requests).